### PR TITLE
Binary fixes

### DIFF
--- a/src/dbarts/bartFit.cpp
+++ b/src/dbarts/bartFit.cpp
@@ -745,6 +745,7 @@ namespace {
       if (control.keepTrainingFits) {
         double* trainingSamples = results.trainingSamples + sampleOffset;
         std::memcpy(trainingSamples, trainingSample, data.numObservations * sizeof(double));
+        if (data.offset != NULL) ext_addVectorsInPlace(data.offset, data.numObservations, 1.0, trainingSamples);
       }
       
       sampleOffset = simNum * data.numTestObservations;


### PR DESCRIPTION
Test script

```
library(dbarts); library(nnet)

set.seed(22)

offset = -.5

X <- matrix(rnorm(500*2),500,2)
gam <- 0.25*(sin((X[,1]+X[,2])*pi)+X[,1]) + offset
Y <- as.numeric(gam+rnorm(500) > 0)
set.seed(9)
bartfit1 <- bart(X,Y,x.test=X,binaryOffset=offset)
set.seed(9)
bartfit2 <- bart(X,Y)
set.seed(9)
bartfit3 <- BayesTree::bart(X, Y, x.test=X, binaryOffset=offset)

# Using the ref interface
set.seed(9)
dbf <- dbarts(Y~., data.frame(Y=Y, X=X), offset=offset*rep(1, 500))
bartfit5 <- dbf$run()

# OK
print(bartfit1$yhat.train[1:10])
print(bartfit2$yhat.train[1:10])

# All agree, up to monte carlo error
plot(gam, colMeans(bartfit1$yhat.train), col=Y+1); abline(0,1)
plot(gam, colMeans(bartfit2$yhat.train), col=Y+1); abline(0,1)
plot(gam, colMeans(bartfit3$yhat.train), col=Y+1); abline(0,1)
plot(gam, rowMeans(bartfit5$train), col=Y+1); abline(0,1)

# yhat.test is missing the offset still, though
plot(gam, colMeans(bartfit1$yhat.test), col=Y+1); abline(0,1)
plot(gam, colMeans(bartfit1$yhat.test+offset), col=Y+1); abline(0,1)

#compare to BayesTree, which does include the offset
plot(gam, colMeans(bartfit3$yhat.test), col=Y+1); abline(0,1)

#plot(gam, colMeans(bartfit3$yhat.train), col=Y+1); abline(0,1)
#plot(gam, colMeans(bartfit4$yhat.train), col=Y+1); abline(0,1)
```
