### PR TITLE
Small fix rbart out_of_group random effect

### DIFF
--- a/R/rbart.R
+++ b/R/rbart.R
@@ -429,7 +429,7 @@ packageRbartResults <- function(control, data, group.by, group.by.test, chainRes
       n.samples <- dim(chainResults[[1L]]$ranef)[2L]
       n.unmeasured <- sum(unmeasuredLevels)
       totalRanef <- sapply(seq_along(chainResults), function(k) {
-        unmeasuredRanef <- matrix(rnorm(n.unmeasured * n.samples, 0, rep(chainResults[[k]]$tau, rep_len(n.samples, n.unmeasured))),
+        unmeasuredRanef <- matrix(rnorm(n.unmeasured * n.samples, 0, rep(chainResults[[k]]$tau, rep_len(n.unmeasured, n.samples))),
                                   n.unmeasured, n.samples, dimnames = list(levels(group.by.test)[unmeasuredLevels], NULL))
         rbind(chainResults[[k]]$ranef, unmeasuredRanef)
       })


### PR DESCRIPTION
Hi,

I've been working with the rbart_vi function and encountered an issue when making predictions with out-of-sample groups in the test. After reviewing the code, I've identified that the error is due to a mismatch in dimensions within the rep. I believe that this small change is the correct fix. I've run the code with this small variation, and it works.