### PR TITLE
fix object not found in rbart_vi

### DIFF
--- a/R/rbart.R
+++ b/R/rbart.R
@@ -67,7 +67,7 @@ rbart_vi <- function(
 
   if (!is.null(matchedCall[["k"]])) {
     node.prior <- quote(normal(k))
-    node.prior[[2L]] <- matchedCall[["k"]]
+    node.prior[[2L]] <- k
   } else {
     node.prior <- NULL
   }


### PR DESCRIPTION
Hi @vdorie,

I’ve made a change to address the issue with k not being evaluated properly in rbart_vi.

While tuning the hyperparameters for rbart_vi, I found the error: **_object 'k' not found._**

Looking into the code, I noticed that k is not evaluated like the other hyperparameters:

**Line 70**: `node.prior[[2L]] <- matchedCall[["k"]]`,
**Line 66**: `tree.prior[[2L]] <- power; tree.prior[[3L]] <- base`

Bellow is an small example that reproduces the issue

```
library('dbarts')

train <- ToothGrowth[1:45,]; test <- ToothGrowth[46:60,]

# Returns an error: 
# error running multithreaded, defaulting to single: 4 nodes produced errors; first error: object 'k' not found
k <- 1.8
m1 <- rbart_vi(len ~ . - supp, data = train, test = test, group.by = supp, group.by.test = supp,
         k = k)

# No error when k is provided directly 
m2 <- rbart_vi(len ~ . - supp, data = train, test = test, group.by = supp, group.by.test = supp,
         k = 1.8)
```

Would you be able to take a look at this? I appreciate your time and any insights you may have.

Thanks in advance!
