### PR TITLE
Fix CRAN build errors

### DIFF
--- a/R/A_class.R
+++ b/R/A_class.R
@@ -146,7 +146,7 @@ methods::setValidity("dbartsControl",
       return("'printCutoffs' must be a non-negative integer")
     
     ## try to extract rng kinds from function text
-    rngKind <- parse(text = deparse(RNGkind)[-1L])[[1L]]
+    rngKind <- body(RNGkind)
     rngKinds <- character(0L)
     rngNormalKinds <- character(0L)
     for (i in seq_along(rngKind)) {

--- a/src/R_interface.cpp
+++ b/src/R_interface.cpp
@@ -341,7 +341,7 @@ namespace std {
 #endif
 
 extern "C" {
-#define DEF_FUNC(_N_, _F_, _A_) {_N_, std::bit_cast<DL_FUNC>(&(_F_)), _A_}
+#define DEF_FUNC(_N_, _F_, _A_) {_N_, (DL_FUNC) &(_F_), _A_}
 
 static R_CallMethodDef R_callMethods[] = {
   DEF_FUNC("dbarts_create", create, 3),
@@ -418,7 +418,7 @@ typedef struct {
   DL_FUNC function;
 } C_CallMethodDef;
 
-#define DEF_FUNC(_N_, _F_) {_N_, std::bit_cast<DL_FUNC>(&(_F_))}
+#define DEF_FUNC(_N_, _F_) {_N_, (DL_FUNC) &(_F_)}
 
 static C_CallMethodDef C_callMethods[] = {
   DEF_FUNC("createCGMPrior", dbarts_createCGMPrior),


### PR DESCRIPTION
## Background 

First off, thanks for this wonderful package! I am the maintainer of an R package [countSTAR](https://bking124.github.io/countSTAR/), a downstream CRAN package that suggests `dbarts`. The recent `dbarts` check failures prevent CRAN from checking `countSTAR` with all suggested packages available, so I investigated the reported failures and prepared these small fixes.

CRAN has requested that the check problems be resolved by August 21, after which `dbarts` may be archived. This would also affect downstream packages.

 ## Changes
 
 - Replace the `deparse()`/`parse()` reconstruction of `RNGkind()` with
   `body(RNGkind)`.
 
   Recent R-devel versions added another argument to `RNGkind()`. Its
   deparsed function header can therefore span multiple lines, causing the
   existing code—which removes only the first line—to leave invalid R code.
   `body(RNGkind)` retrieves the intended language object directly without
   depending on how the function is formatted when deparsed.
 
 - Replace `std::bit_cast<DL_FUNC>` in the native routine registration
   tables with the conventional `(DL_FUNC)` cast used in R package
   registration code.
 
   This should hopefully address the reported Intel macOS failure, where C++20 mode is
   enabled but the available standard library does not provide
   `std::bit_cast`.
 
 ## Testing
 
 I ran an R-hub check using R-devel, and the package passed with the RNGKind
 changes.
 
 I have less experience with the C++ portion of the package and could not reproduce the exact Intel MacOS CRAN environment locally. The replacement uses the `DL_FUNC` pattern documented for R routine registration [here](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Registering-native-routines-1), so I believe it should resolve the reported failure, but please let me know if I've missed something. Either way, hopefully this should be straightforward to confirm on the affected CRAN check platform. 